### PR TITLE
Fix Herbie Links in Roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,10 +7,10 @@
 4. Weather maps from new Zarr datafiles.
 5. Add in alerts for Canada/ EU/ other.
 6. Add source data.
-	* Add in the Canadian models ([HRDPS](https://herbie.readthedocs.io/en/stable/user_guide/tutorial/model_notebooks/hrdps.html), [GDPS](https://herbie.readthedocs.io/en/stable/user_guide/tutorial/model_notebooks/gdps.html))
-	* [NOAA GraphCast](https://aws.amazon.com/marketplace/pp/prodview-owtdhh6w3k3c2?sr=0-1&ref_=beagle&applicationId=AWSMPContessa)?
-	* [ECMWF](https://herbie.readthedocs.io/en/stable/user_guide/tutorial/model_notebooks/ecmwf.html)
-	* [RTMA/ URMA](https://herbie.readthedocs.io/en/stable/user_guide/tutorial/model_notebooks/rtma.html)
-	* [NBM-Alaska/ Hawaii/ Puerto Rico/ Guam](https://herbie.readthedocs.io/en/stable/user_guide/tutorial/model_notebooks/nbm.html)
+	* Add in the Canadian models ([HRDPS](https://herbie.readthedocs.io/en/stable/gallery/eccc_models/hrdps.html), [GDPS](https://herbie.readthedocs.io/en/stable/gallery/eccc_models/gdps.html))
+	* [NOAA GraphCast](https://herbie.readthedocs.io/en/stable/gallery/noaa_models/gfs.html#GFS-GraphCast)?
+	* [ECMWF](https://herbie.readthedocs.io/en/stable/gallery/ecmwf_models/ecmwf.html)
+	* [RTMA/ URMA](https://herbie.readthedocs.io/en/stable/gallery/noaa_models/rtma-urma.html)
+	* [NBM-Alaska/ Hawaii/ Puerto Rico/ Guam](https://herbie.readthedocs.io/en/stable/gallery/noaa_models/nbm.html)
 7. Investigate using radar data/station data.
     *  Investigate if it's feasible to use radar data and/or station data for the currently conditions. This is a suggestion in [issue #10](https://github.com/alexander0042/pirateweather/issues/10).


### PR DESCRIPTION
As pointed out in #262 the herbie links in the roadmap pointed to dead links as herbie had made some changes to their docs. I was able to find the new URL scheme for the links and update them to the new URLs.