### PR TITLE
Update docs for v2.2

### DIFF
--- a/PW_OpenAPI.yaml
+++ b/PW_OpenAPI.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 2.1.2
+  version: 2.2
   title: Pirate Weather API
   description: Pirate Weather provides an open, free, and documented source of government weather data.
   termsOfService: https://pirate-weather.apiable.io/terms
@@ -704,7 +704,7 @@ components:
         version:
           type: string
           description: The version of Pirate Weather used to generate the forecast.
-          example: V2.1.2
+          example: V2.2
         sourceIDX:
           type: object
           description: The X, Y coordinate and the lat/long coordinate for each model used to generate the forecast. Only returned when version>2.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ For a RSS feed of these changes, subscribe using this link: <https://github.com/
 	* August 20, 2024, API Version 2.2
 		* Fixed the pressure variable showing surface level pressure instead of sea level pressure in the HRRR domain
 
-???+ note "Version 2.1"
+??? note "Version 2.1"
 
 	* August 16, 2024, API Version 2.1.2
 		* Fixed the pressure variable showing surface level pressure instead of sea level pressure in the HRRR domain

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 For a RSS feed of these changes, subscribe using this link: <https://github.com/alexander0042/pirateweather/commits/main.atom>.
 
+???+ note "Version 2.2"
+
+	* August 20, 2024, API Version 2.2
+		* Fixed the pressure variable showing surface level pressure instead of sea level pressure in the HRRR domain
+
 ???+ note "Version 2.1"
 
 	* August 16, 2024, API Version 2.1.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,10 @@ For a RSS feed of these changes, subscribe using this link: <https://github.com/
 ???+ note "Version 2.2"
 
 	* August 20, 2024, API Version 2.2
-		* Fixed the pressure variable showing surface level pressure instead of sea level pressure in the HRRR domain
+		* No endpoint facing changes, but a lot of backend reworking 
+			* Switched back from the LMDB to a file based approach for ingesting new data, with a new timing function for updates. This approach is also faster, with most requests returning in <10 ms
+			* Changed how Kong checks API keys to simplify the update roadmap for Kong
+			* Added a container restart policy for the dev container to allow for faster updates  
 
 ??? note "Version 2.1"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Alternatively, I also have a GitHub Sponsorship page set up on my [profile](http
 <iframe src="https://github.com/sponsors/alexander0042/card" title="Sponsor alexander0042" height="225" width="600" style="border: 0;"></iframe>
 
 ## Recent Updates- Summer 2024
-Up to version 2.1! As always, details are available in the [changelog](https://pirateweather.net/en/latest/changelog/).
+Up to version 2.2! As always, details are available in the [changelog](https://pirateweather.net/en/latest/changelog/).
 
 * Moved things from disk based storage to a [Zarr arrays backed by LMDB database](http://www.lmdb.tech/doc/) which fixes the issue of the API returning weird results as reported in:
   * [issue #229](https://github.com/Pirate-Weather/pirateweather/issues/229)


### PR DESCRIPTION
Noticed the version number got increased to V2.2 this morning which I assume fixes #297? Either way I've created a branch for you to update the changelog and the index page with details of the 2.2 update.