### PR TITLE
V2.3.3 Update Docs

### DIFF
--- a/PW_OpenAPI.yaml
+++ b/PW_OpenAPI.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: "2.3.1"
+  version: "2.3.3"
   title: Pirate Weather API
   description: Pirate Weather provides an open, free, and documented source of government weather data.
   termsOfService: https://pirate-weather.apiable.io/terms
@@ -763,7 +763,7 @@ components:
         version:
           type: string
           description: The version of Pirate Weather used to generate the forecast.
-          example: V2.3.1
+          example: V2.3.3
         sourceIDX:
           type: object
           description: The X, Y coordinate and the lat/long coordinate for each model used to generate the forecast. Only returned when version>2.

--- a/PW_OpenAPI.yaml
+++ b/PW_OpenAPI.yaml
@@ -274,6 +274,18 @@ components:
           type: number
           description: The apparent temperature reported by NBM and gfs. Only returned when version>2.
           example: 16.06          
+        currentDayIce:
+          type: number
+          description: The ice precipitation that has accumulated so far during the day, from midnight until the forecast request time. Only returned when version>2.
+          example: 0.02
+        currentDayLiquid:
+          type: number
+          description: The liquid precipitation that has accumulated so far during the day, from midnight until the forecast request time. Only returned when version>2.
+          example: 0.20 
+        currentDaySnow:
+          type: number
+          description: The snow precipitation that has accumulated so far during the day, from midnight until the forecast request time. Only returned when version>2.
+          example: 2.02           
     minutely:
       type: object
       description: A block containing minute-by-minute precipitation intensity for the next 60 minutes.

--- a/docs/API.md
+++ b/docs/API.md
@@ -508,16 +508,13 @@ The time of the minimum "feels like" temperature during the daytime, from 6:00 a
 Percentage of the sky that is covered in clouds. This value will be between 0 and 1 inclusive. Calculated from the the [GFS (#650)](https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.1p00.f003.shtml) or [HRRR (#115)](https://rapidrefresh.noaa.gov/hrrr/HRRRv4_GRIB2_WRFTWO.txt) `TCDC` variable for the entire atmosphere.
 
 #### currentDayIce
-**Only on `currently`**. 
-The ice precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+**Only on `currently`**. The ice precipitation that has accumulated so far during the day, from midnight until the forecast request time.
 
 #### currentDayLiquid
-**Only on `currently`**. 
-The liquid precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+**Only on `currently`**. The liquid precipitation that has accumulated so far during the day, from midnight until the forecast request time.
 
 #### currentDaySnow
-**Only on `currently`**. 
-The snow precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+**Only on `currently`**. The snow precipitation that has accumulated so far during the day, from midnight until the forecast request time.
 
 #### dawnTime
 **Only on `daily`**. The time when the the sun is a specific (6 degrees) height above the horizon after sunrise. Calculated from [Astal dawn defaults](https://astral.readthedocs.io/en/latest/package.html?highlight=dawn#astral.sun.dawn).

--- a/docs/API.md
+++ b/docs/API.md
@@ -61,6 +61,9 @@ For compatibility with Dark Sky, `us` (Imperial units) are the default if nothin
 | precipIntensity | Millimetres per hour | Millimetres per hour | Millimetres per hour | Inches per hour |
 | precipIntensityMax | Millimetres per hour | Millimetres per hour | Millimetres per hour | Inches per hour |
 | precipAccumulation | Centimetres | Centimetres | Centimetres | Inches |
+| liquidAccumulation   | Centimetres | Centimetres | Centimetres | Inches |
+| snowAccumulation | Centimetres | Centimetres | Centimetres | Inches |
+| iceAccumulation | Centimetres | Centimetres | Centimetres | Inches |
 | temperature | Degrees Celsius | Degrees Celsius | Degrees Celsius | Degrees Fahrenheit |
 | temperatureMin | Degrees Celsius | Degrees Celsius | Degrees Celsius | Degrees Fahrenheit |
 | temperatureMax | Degrees Celsius | Degrees Celsius | Degrees Celsius | Degrees Fahrenheit |
@@ -504,6 +507,18 @@ The time of the minimum "feels like" temperature during the daytime, from 6:00 a
 #### cloudCover
 Percentage of the sky that is covered in clouds. This value will be between 0 and 1 inclusive. Calculated from the the [GFS (#650)](https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.1p00.f003.shtml) or [HRRR (#115)](https://rapidrefresh.noaa.gov/hrrr/HRRRv4_GRIB2_WRFTWO.txt) `TCDC` variable for the entire atmosphere.
 
+#### currentDayIce
+**Only on `currently`**. 
+The ice precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+
+#### currentDayLiquid
+**Only on `currently`**. 
+The liquid precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+
+#### currentDaySnow
+**Only on `currently`**. 
+The snow precipitation that has accumulated so far during the day, from midnight until the forecast request time.
+
 #### dawnTime
 **Only on `daily`**. The time when the the sun is a specific (6 degrees) height above the horizon after sunrise. Calculated from [Astal dawn defaults](https://astral.readthedocs.io/en/latest/package.html?highlight=dawn#astral.sun.dawn).
 
@@ -708,7 +723,7 @@ Indicates how severe the weather alert is. Possible values are:
 * Unknown
 
 #### time
-The time in which the alert was issued represented in UNIX time.
+The time in which the alert was issued represented in UNIX time. From the NWS `effective` time.
 
 #### expires
 The time in which the alert expires represented in UNIX time.

--- a/docs/API.md
+++ b/docs/API.md
@@ -241,7 +241,7 @@ If `version=2` is included fields which were not part of the Dark Sky API will b
 	    },
 	   "nearest-station": 0,
 	   "units": "ca",
-	   "version": "V2.3.1"
+	   "version": "V2.3.3"
 	   }
 	}
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -597,7 +597,7 @@ The density of total atmospheric ozone at a given time in Dobson units.
 **Only on `hourly` and `daily`**. The total amount of liquid precipitation expected to fall over an hour or a day expressed in centimetres or inches depending on the requested `units`. For day 0, this is the precipitation during the remaining hours of the day.
 
 #### precipIntensity
-The rate in which liquid precipitation is falling. This value is expressed in millimetres per hour or inches per hour depending on the requested `units`. For `currently` and `minutely` forecast blocks, the HRRR "Precipitation Rate" variable  is used where available, otherwise averaged GEFS data is returned. For `hourly` and `daily` forecast blocks, GEFS is always used. This is done so that the `precipIntensityProbablity` variable is aligned with the intensity.
+The rate in which liquid precipitation is falling. This value is expressed in millimetres per hour or inches per hour depending on the requested `units`.
 
 #### precipIntensityError
 The standard deviation of the `precipIntensity` from the GEFS model.

--- a/docs/DataSources.md
+++ b/docs/DataSources.md
@@ -32,6 +32,9 @@ At a high level, the general approach is to use NBM first, then HRRR, then GEFS,
 |-----------------------|-----------------------|-----------------------|---------------------------|
 |apparentTemperature	|HRRR_SubH > NBM > GFS	|N/A   				    |NBM > HRRR > GFS		 	|
 |cloudCover   			|NBM > HRRR > GFS   	|N/A   				    |NBM > HRRR > GFS   		|
+|currentDayIce		    |NBM > HRRR > GEFS > GFS|N/A					|N/A						|
+|currentDayLiquid       |NBM > HRRR > GEFS > GFS|N/A					|N/A						|
+|currentDaySnow         |NBM > HRRR > GEFS > GFS|N/A					|N/A						|
 |dewPoint     			|HRRR_SubH > NBM > GFS  |N/A   				    |NBM > HRRR > GFS   		|
 |fireIndex    			|NBM   			  		|N/A   				    |NBM   			 			|
 |feelsLike    			|NBM > GFS  			|N/A   				    |NBM > GFS		 			|

--- a/docs/DataSources.md
+++ b/docs/DataSources.md
@@ -19,7 +19,7 @@ The GFS model also underpins the Global Ensemble Forecast System [(GEFS)](https:
 The Global Ensemble Forecast System [(GEFS)](https://www.ncei.noaa.gov/products/weather-climate-models/global-ensemble-forecast) is the ensemble version of NOAA's GFS model. By running different variations parameters and inputs, 30 different versions of this model are run at the same time, providing 3-hour forecasts out to 240 hours. The API uses the GEFS to get precipitation type, quantity, and probability, since it seemed like the most accurate way of determining this. I have no idea how Dark Sky did it, and I am very open to feedback about other ways it could be assigned, since getting the precipitation probability number turned out to be one of the most complex parts of the entire setup! 
 
 ### ERA5
-To provide historic weather data, the [European Reanalysis 5 Dataset](https://registry.opendata.aws/ecmwf-era5/) is used. This source is particularly interesting, since unlike the real-time NOAA models that I need to convert, it's provided in the "cloud native" [Zarr](https://zarr.readthedocs.io/en/stable/) file format. This lets the data be accessed directly and quickly in S3 from Lambda. There aren't nearly as many, many parameters available as with the GFS or HRRR models, but there are enough to cover the most important variables. 
+To provide historic weather data, the [NCAR European Reanalysis 5 Dataset](https://registry.opendata.aws/nsf-ncar-era5/) is used. This source uses NetCDF4 files saved on S3, which lets them be accessed directly from S3; however, it's not particularly fast, making it only suitable for historic requests. 
 
 
 ## Forecast element sources

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,11 +3,16 @@
 For a RSS feed of these changes, subscribe using this link: <https://github.com/alexander0042/pirateweather/commits/main.atom>.
 
 ???+ note "Version 2.3"
-	* October 22, 2024, API Version 2.3.3
-		* Simplify US alert headline details  per [issue #344](https://github.com/Pirate-Weather/pirateweather/issues/344).
-		* Correct how Current Fire Index outside of NBM area is returned. -999 (for "No Data" is now displayed instead of 0.
+	* October 25, 2024, API Version 2.3.3
+		* Updated cache parameters per [issue #350](https://github.com/Pirate-Weather/pirateweather/issues/350). 
+		* Changed alert start time to use NWS effective time instead of onset time per [issue #353](https://github.com/Pirate-Weather/pirateweather/issues/353). 
+		* Added line breaks in NWS alert descriptions [issue #353](https://github.com/Pirate-Weather/pirateweather/issues/353). 
+		* Removed extra white space in NWS alert regions per [issue #353](https://github.com/Pirate-Weather/pirateweather/issues/353). 
+		* Fixed a rounding issue in precipitation intensity per [issue #211](https://github.com/Pirate-Weather/pirateweather/issues/211). 
+		* Added current day precipitation per [issue #211](https://github.com/Pirate-Weather/pirateweather/issues/211). 
+		* Added a check to filter invalid data per [issue #354](https://github.com/Pirate-Weather/pirateweather/issues/354).  
 	* October 7, 2024, API Version 2.3.2
-		* Simplify US alert headline details  per [issue #344](https://github.com/Pirate-Weather/pirateweather/issues/344).
+		* Simplify US alert headline details per [issue #344](https://github.com/Pirate-Weather/pirateweather/issues/344).
 		* Correct how Current Fire Index outside of NBM area is returned. -999 (for "No Data" is now displayed instead of 0.
 	* September 23, 2024, API Version 2.3.1
 		* Fixed some issues with Time Machine causing slow responses for the production API.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 For a RSS feed of these changes, subscribe using this link: <https://github.com/alexander0042/pirateweather/commits/main.atom>.
 
 ???+ note "Version 2.3"
+	* October 22, 2024, API Version 2.3.3
+		* Simplify US alert headline details  per [issue #344](https://github.com/Pirate-Weather/pirateweather/issues/344).
+		* Correct how Current Fire Index outside of NBM area is returned. -999 (for "No Data" is now displayed instead of 0.
 	* October 7, 2024, API Version 2.3.2
 		* Simplify US alert headline details  per [issue #344](https://github.com/Pirate-Weather/pirateweather/issues/344).
 		* Correct how Current Fire Index outside of NBM area is returned. -999 (for "No Data" is now displayed instead of 0.


### PR DESCRIPTION
Started the docs for the V2.3.3 update which fixes:

- Fix #350 
- Fix #354 
- Fix #211 
- Fix #353 

## Checklist

- [x] Update OpenAPI spec
- [x] Update API docs
- [x] Update changelog
- [ ] Update roadmap (if needed)
- [x] ERA5 link needs to be updated to the new AWS dataset on Data Sources Page

I also noticed that there is no section anywhere on how to attribute data anywhere on the site and might be useful? Maybe similar to how [Open-Meteo](https://open-meteo.com/en/license) does it?