### PR TITLE
Create Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Describe the change
+
+## Type of change
+<!-- Pick one of the categories you feel best matches the pull request you created. To mark a box as checked you can change [ ] to [x] and it will be marked after you submit your pull request OR you can submit the pull request and check the box afterwards. -->
+
+- [ ] Updated Home Assistant documentation
+- [ ] General documentation updates (fixing typos, updating information, etc.)
+- [ ] Added item to who is using section
+- [ ] Updated docs for new API version release
+
+## Checklist
+<!-- Not all of these items will apply to your pull request. Check off the items as needed. -->
+
+- This pull request fixes issue: fixes #
+- [ ] Update OpenAPI spec
+- [ ] Update API documentation
+- [ ] Update recent updates section
+- [ ] Update changelog
+- [ ] Update roadmap
+- [ ] Update data sources page


### PR DESCRIPTION
## Describe the change
I noticed when creating the PRs for new version doc updates that I have to manually add the checklist to each PR I create. I thought it might be helpful to create a PR template so that I don't have to create it each time I create a new PR.

I'm using the pull request template in this pull request so you can get a feel for how it works. All the text is displayed in Markdown so it can be easily removed but still might be useful. I can always change the wording in case anything might confuse someone.

## Type of change
<!-- Pick one of the categories you feel best matches the pull request you created. To mark a box as checked you can change [ ] to [x] and it will be marked after you submit your pull request OR you can submit the pull request and check the box afterwards. -->

- [ ] Updated Home Assistant documentation
- [ ] General documentation updates (fixing typos, updating information, etc.)
- [ ] Added item to who is using section
- [ ] Updated docs for new API version release
- [x] Meta change

## Checklist
<!-- Not all of these items will apply to your pull request. Check off the items as needed. -->

- This pull request fixes issue: fixes #
- [ ] Update OpenAPI spec
- [ ] Update API documentation
- [ ] Update recent updates section
- [ ] Update changelog
- [ ] Update roadmap
- [ ] Update data sources page