### PR TITLE
Change minor doc typo from "buckled" to "bucket"

### DIFF
--- a/docs/DataSources.md
+++ b/docs/DataSources.md
@@ -62,7 +62,7 @@ At a high level, the general approach is to use NBM first, then HRRR, then GEFS,
 ## Data Pipeline
 
 ### Trigger
-Forecasts are saved from NOAA onto the [AWS Public Cloud](https://registry.opendata.aws/collab/noaa/) into three buckets for the [HRRR](https://registry.opendata.aws/noaa-hrrr-pds/), [GFS](https://registry.opendata.aws/noaa-gfs-bdp-pds/), and [GEFS](https://registry.opendata.aws/noaa-gefs/) models. Since I couldn't find a good way to trigger processing tasks based on S3 events in a public buckled, the ingest system relies on timed events scheduled through [AWS EventBridge Rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html), with the timings shown in the table below:
+Forecasts are saved from NOAA onto the [AWS Public Cloud](https://registry.opendata.aws/collab/noaa/) into three buckets for the [HRRR](https://registry.opendata.aws/noaa-hrrr-pds/), [GFS](https://registry.opendata.aws/noaa-gfs-bdp-pds/), and [GEFS](https://registry.opendata.aws/noaa-gefs/) models. Since I couldn't find a good way to trigger processing tasks based on S3 events in a public bucket, the ingest system relies on timed events scheduled through [AWS EventBridge Rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html), with the timings shown in the table below:
 
 | Model                | Run Times (UTC) | Delay | Ingest Times (UTC)    |
 |----------------------|-----------------|-------|-----------------------|


### PR DESCRIPTION
## Describe the change
The `Data Sources` page under the `Data Pipeline` section says
```
Since I couldn't find a good way to trigger processing tasks based on S3 events in a public buckled
```
This seems to be a typo.  This PR changes this text to
```
Since I couldn't find a good way to trigger processing tasks based on S3 events in a public bucket
```

## Type of change
<!-- Pick one of the categories you feel best matches the pull request you created. To mark a box as checked you can change [ ] to [x] and it will be marked after you submit your pull request OR you can submit the pull request and check the box afterwards. -->

- [ ] Updated Home Assistant documentation
- [x] General documentation updates (fixing typos, updating information, etc.)
- [ ] Added item to who is using section
- [ ] Updated docs for new API version release

## Checklist
<!-- Not all of these items will apply to your pull request. Check off the items as needed. -->

- This pull request fixes issue: fixes #
- [ ] Update OpenAPI spec
- [ ] Update API documentation
- [ ] Update recent updates section
- [ ] Update changelog
- [ ] Update roadmap
- [x] Update data sources page