### PR TITLE
Update TimeMachine docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -340,7 +340,7 @@ Crucially, there's now three different ways a request could be handled:
 	* Can provide the range of PW forecast variables via the `tmextra` parameter
 	* Avoids the ERA5 production time lag
 	* Slow (~30 seconds), since it needs to open and read many zarr files on S3
-3. T-minus 48 hours onward: merged 1-hour forecast data with foreward looking forecast data, responding with the full 7 day forecast.
+3. T-minus 48 hours onward: merged 1-hour forecast data with forward looking forecast data, responding with the full 7 day forecast.
 	* Same process as before using the API endpoint with the time variable.
 	* Very fast (10 ms), since this is optimized for fast reads in one location
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -335,13 +335,13 @@ Crucially, there's now three different ways a request could be handled:
 	* 24 hours
 	* Subset of variables
 	* Slowish (~10 seconds)
-2. 3 or 4 months behind realtime, to T-minus 24 hours: GFS/HRRR/NBM 1-hour forecast data from the PW archive
+2. 3 or 4 months behind realtime, to T-minus 48 hours: GFS/HRRR/NBM 1-hour forecast data from the PW archive
 	* Provides more data and resolution than is available on ERA5
 	* Can provide the range of PW forecast variables via the `tmextra` parameter
 	* Avoids the ERA5 production time lag
 	* Slow (~30 seconds), since it needs to open and read many zarr files on S3
-3. T-minus 24 hours onward: merged 1-hour forecast data with foreward looking forecast data, responding with the full 7 day forecast.
-	* Same process as before!
+3. T-minus 48 hours onward: merged 1-hour forecast data with foreward looking forecast data, responding with the full 7 day forecast.
+	* Same process as before using the API endpoint with the time variable.
 	* Very fast (10 ms), since this is optimized for fast reads in one location
 
 The response format is the same as the forecast except:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -397,6 +397,8 @@ For a RSS feed of these changes, subscribe using this link: <https://github.com/
 
 ## Time Machine Changelog
 
+* July 16, 2025
+	* Change the number of saved data on the API endpoint to 48 hours from 36 hours as per [PR #180](https://github.com/Pirate-Weather/pirate-weather-code/pull/180)
 * December 9, 2024
 	* Added a per API key rate limit of 1 to 4/ per second (depending on the plan) to prevent instabililty as per [https://github.com/Pirate-Weather/pirate-weather-code/issues/30#issuecomment-2528680513](https://github.com/Pirate-Weather/pirate-weather-code/issues/30#issuecomment-2528680513)
 * September 13, 2024


### PR DESCRIPTION
## Describe the change
Update the TimeMachine docs to clarify that the last 48 hours of data is on the API endpoint.

## Type of change
<!-- Pick one of the categories you feel best matches the pull request you created. To mark a box as checked you can change [ ] to [x] and it will be marked after you submit your pull request OR you can submit the pull request and check the box afterwards. -->

- [ ] Updated Home Assistant documentation
- [x] General documentation updates (fixing typos, updating information, etc.)
- [ ] Added item to who is using section
- [ ] Updated docs for new API version release

## Checklist
<!-- Not all of these items will apply to your pull request. Check off the items as needed. -->

- This pull request fixes issue: fixes #494
- [ ] Update OpenAPI spec
- [x] Update API documentation
- [ ] Update recent updates section
- [x] Update changelog
- [ ] Update roadmap
- [ ] Update data sources page