### PR TITLE
docs: add AccessiWeather to usage list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,6 @@
 - [Chrome Pirate Weather Extension](https://chromewebstore.google.com/detail/pirate-weather-extension/akfgfkkfjpbpplibpcffankjdjgpkedd) - Chrome extension for precipitation alerts, forecasts, and saved locations.
 
 - [AccessiWeather](https://github.com/Orinks/AccessiWeather) - Accessible cross-platform weather app with screen-reader-friendly forecasts, alerts, and Pirate Weather support.
-
 ## Libraries
 - [python-pirate-weather](https://github.com/cloneofghosts/python-pirate-weather) - A thin Python Wrapper for the Pirate Weather API forked from the [forecastio python library](https://github.com/ZeevG/python-forecast.io).
 - [pirate-weather-python](https://github.com/Pirate-Weather/pirate-weather-python)


### PR DESCRIPTION
## Summary
- add AccessiWeather to the Pirate Weather site list of apps using Pirate Weather
- describe it as an accessible cross-platform weather app with screen-reader-friendly forecasts, alerts, and Pirate Weather support

AccessiWeather repo: https://github.com/Orinks/AccessiWeather