### PR TITLE
Add Temperature Report to Who is using Pirate Weather?

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,8 @@
 - [Weathergraph](https://weathergraph.app/) - Graphical hour-by-hour forecast & widget for iOS, Apple Watch and mac
 - [Pirate Weather for KDE Plasma](https://github.com/txhammer68/pirateWeather) - KDE Plasma 6 weather widget
 - [Chrome Pirate Weather Extension](https://chromewebstore.google.com/detail/pirate-weather-extension/akfgfkkfjpbpplibpcffankjdjgpkedd) - Chrome extension for precipitation alerts, forecasts, and saved locations.
-
 - [AccessiWeather](https://github.com/Orinks/AccessiWeather) - Accessible cross-platform weather app with screen-reader-friendly forecasts, alerts, and Pirate Weather support.
+- [Temperature Report](https://temperature.report/) - Weather website designed to make it easy to see an overview of upcoming weather.
 ## Libraries
 - [python-pirate-weather](https://github.com/cloneofghosts/python-pirate-weather) - A thin Python Wrapper for the Pirate Weather API forked from the [forecastio python library](https://github.com/ZeevG/python-forecast.io).
 - [pirate-weather-python](https://github.com/Pirate-Weather/pirate-weather-python)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@
 - [Chrome Pirate Weather Extension](https://chromewebstore.google.com/detail/pirate-weather-extension/akfgfkkfjpbpplibpcffankjdjgpkedd) - Chrome extension for precipitation alerts, forecasts, and saved locations.
 - [AccessiWeather](https://github.com/Orinks/AccessiWeather) - Accessible cross-platform weather app with screen-reader-friendly forecasts, alerts, and Pirate Weather support.
 - [Temperature Report](https://temperature.report/) - Weather website designed to make it easy to see an overview of upcoming weather.
+
 ## Libraries
 - [python-pirate-weather](https://github.com/cloneofghosts/python-pirate-weather) - A thin Python Wrapper for the Pirate Weather API forked from the [forecastio python library](https://github.com/ZeevG/python-forecast.io).
 - [pirate-weather-python](https://github.com/Pirate-Weather/pirate-weather-python)


### PR DESCRIPTION
## Describe the change
Added my weather app to the "Who is using Pirate Weather?" page

## Type of change
- [ ] Updated Home Assistant documentation
- [ ] General documentation updates (fixing typos, updating information, etc.)
- [x] Added item to who is using section
- [ ] Updated docs for new API version release

## Checklist

- [ ] Update OpenAPI spec
- [ ] Update API documentation
- [ ] Update recent updates section
- [ ] Update changelog
- [ ] Update data sources page
