### PR TITLE
Add Roam Weather to "Who is using" list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@
 - [Chrome Pirate Weather Extension](https://chromewebstore.google.com/detail/pirate-weather-extension/akfgfkkfjpbpplibpcffankjdjgpkedd) - Chrome extension for precipitation alerts, forecasts, and saved locations.
 - [AccessiWeather](https://github.com/Orinks/AccessiWeather) - Accessible cross-platform weather app with screen-reader-friendly forecasts, alerts, and Pirate Weather support.
 - [Temperature Report](https://temperature.report/) - Weather website designed to make it easy to see an overview of upcoming weather.
+- [Roam Weather](https://weather.roamapps.com) - Weather app built for outdoor enthusiasts (offline support, multi-location viewing, etc)
 
 ## Libraries
 - [python-pirate-weather](https://github.com/cloneofghosts/python-pirate-weather) - A thin Python Wrapper for the Pirate Weather API forked from the [forecastio python library](https://github.com/ZeevG/python-forecast.io).


### PR DESCRIPTION
## Describe the change

Adding Roam Weather to the "Who is using Pirate Weather" docs list! (I'm the developer of Roam Weather 🙂 Pirate Weather's proven to be more accurate than NOAA API, I'm a huge fan!)

## Type of change
<!-- Pick one of the categories you feel best matches the pull request you created. To mark a box as checked you can change [ ] to [x] and it will be marked after you submit your pull request OR you can submit the pull request and check the box afterwards. -->

- [ ] Updated Home Assistant documentation
- [ ] General documentation updates (fixing typos, updating information, etc.)
- [x] Added item to who is using section
- [ ] Updated docs for new API version release

## Checklist
<!-- Not all of these items will apply to your pull request. Check off the items as needed. -->

- This pull request fixes issue: fixes #
- [ ] Update OpenAPI spec
- [ ] Update API documentation
- [ ] Update recent updates section
- [ ] Update changelog
- [ ] Update data sources page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Roam Weather to the list of applications using Pirate Weather.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->